### PR TITLE
Support all response classes

### DIFF
--- a/src/Middleware/RespondWithSecurityHeaders.php
+++ b/src/Middleware/RespondWithSecurityHeaders.php
@@ -6,7 +6,7 @@ namespace TheRobFonz\SecurityHeaders\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 use TheRobFonz\SecurityHeaders\SecurityHeadersGenerator;
 
 class RespondWithSecurityHeaders

--- a/src/SecurityHeadersGenerator.php
+++ b/src/SecurityHeadersGenerator.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace TheRobFonz\SecurityHeaders;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 
 class SecurityHeadersGenerator
 {

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -142,6 +142,34 @@ class MiddlewareTest extends TestCase
         }
     }
 
+    public function test_redirect_response(): void
+    {
+        config([
+            'security.enabled' => true,
+        ]);
+
+        Route::get('redirect', function () {
+            return redirect('/');
+        });
+
+        $this->get('/redirect')
+            ->assertRedirect();
+    }
+
+    public function test_json_response(): void
+    {
+        config([
+            'security.enabled' => true,
+        ]);
+
+        Route::get('some-json', function () {
+            return response()->json(['foo' => 'bar']);
+        });
+
+        $this->get('/some-json')
+            ->assertOk();
+    }
+
     protected function getResponseHeaders(): ResponseHeaderBag
     {
         return $this->get('middleware-test')


### PR DESCRIPTION
When using redirects following error happened:
`TheRobFonz\SecurityHeaders\SecurityHeadersGenerator::attach(): Argument #1 ($response) must be of type Illuminate\Http\Response, Illuminate\Http\RedirectResponse given...`